### PR TITLE
Arbitrum DAO KYC

### DIFF
--- a/extras/multisigs.json
+++ b/extras/multisigs.json
@@ -28,7 +28,8 @@
     "feeManager": "0x7c68c42De679ffB0f16216154C996C354cF1161B",
     "emergency": "0xf404C5a0c02397f0908A3524fc5eb84e68Bbe60D",
     "blabs_ops": "0x56ebA8dcDcEC3161Dd220c4B4131c27aF201F892",
-    "maxi_ops": "0x5891b90CE909d4c3540d640d2BdAAF3fD5157EAD"
+    "maxi_ops": "0x5891b90CE909d4c3540d640d2BdAAF3fD5157EAD",
+    "kyc_grant_safe": "0xb6BfF54589f269E248f99D5956f1fDD5b014D50e"
   },
   "optimism": {
     "dao": "0x043f9687842771b3dF8852c1E9801DCAeED3f6bc",

--- a/extras/signers.json
+++ b/extras/signers.json
@@ -57,7 +57,7 @@
   "kyc": {
     "Arbitrum": {
       "kycsigner1": "0x5c43d19ee1b9f93143c7c258501ef3ada1204524",
-      "kycsigner2": "0x224d2324c24a066e14831922fec4e052dd4860a3",
+      "kycsigner2": "0x0938BCEfba80bCd958A5d4BEbF6a4AFFafB07eD2",
       "kycsigner3": "0x6edbc5bb151d0bfb203a48b378e88dc5912318f1"
     }
   }

--- a/extras/signers.json
+++ b/extras/signers.json
@@ -58,7 +58,7 @@
     "Arbitrum": {
       "kycsigner1": "0x5c43d19ee1b9f93143c7c258501ef3ada1204524",
       "kycsigner2": "0x224d2324c24a066e14831922fec4e052dd4860a3",
-      "kycsigner3": ""
+      "kycsigner3": "0x6edbc5bb151d0bfb203a48b378e88dc5912318f1"
     }
   }
 }

--- a/extras/signers.json
+++ b/extras/signers.json
@@ -53,5 +53,12 @@
   "emeritus": {
     "solarcurve_signer": "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
     "solarcurve_deployer": "0x6409C2C1aC1B26aaaEF982572efd38412075586D"
+  },
+  "kyc": {
+    "Arbitrum": {
+      "kycsigner1": "0x5c43d19ee1b9f93143c7c258501ef3ada1204524",
+      "kycsigner2": "0x224d2324c24a066e14831922fec4e052dd4860a3",
+      "kycsigner3": ""
+    }
   }
 }


### PR DESCRIPTION
Setup Multisig for handling $ARB from the DAO grant.

Requires a majority of signers to KYC with Arbitrum (but not otherwise dox).

KYCed signers will be named as kycsigner1 - kycsigner3.  

I certify that these are 3 different people all of whom are connected to Balancer.  The Arbitrum KYC process will do the same.