### PR TITLE
arbitrum_vesting_contract_addresses

### DIFF
--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -44,5 +44,16 @@
             "oneinchSwapper": "0xd712A863766dE7e7cA13289A97997E01832A6571",
             "paraswapSwapper": "0x95676AaEcD59B19C5B79008F86d3A291628b0947"
         }
-    }
+    },
+    "maxiVestingContracts": {
+        "factory": "0x7BBAc709a9535464690A435ca7361256496f13Ce",
+        "Tritium": "0x2b03b15E4A26D858DD594649988255eCEb832787",
+        "shak": "0x3e7EC248fd5BE044C0efcE9fAA778AC374350efc",
+        "Xeonus": "0xCE49aeFDDdDBa966cd69e6A4670f4F795F577264",
+        "zekraken": "0x5C8260f4eB66eC847018BBC5f68694864eF094Fe",
+        "Zen Dragon": "0x2466f62D52005AaB7A8F637CC3152361D4CC210c",
+        "Mike B": "0x81DE849AdB5883d089cdFd66bB399b4Af74a16bb",
+        "Danko": "0x2304488F0eddF15227C21b021739448B51E791C0",
+        "Dubstard": "0x01B894622C7aa890d758C8a0E8156480F0Fa5f6C"
+    } 
 }


### PR DESCRIPTION
Adds vester addresses for each maxi on arbitrum. This is where auraBAL will be sent respectively for Q4 2023.