### PR TITLE
Blacklist old wstETH/ETH gauge that is unkilled but doesn't show up in all data sources.

### DIFF
--- a/config/core_pools_blacklist.json
+++ b/config/core_pools_blacklist.json
@@ -2,7 +2,9 @@
   "mainnet": { "0xxxx": "BLACKLIST-ME" },
   "polygon": {},
   "zkevm": {},
-  "arbitrum": {},
+  "arbitrum": {
+    "0x36bf227d6bac96e2ab1ebb5492ecec69c691943f000200000000000000000316": "old wstETH/ETH gauge"
+  },
   "gnosis": {},
   "base": {},
   "avalanche": {},


### PR DESCRIPTION
…n all data sources.

https://app.balancer.fi/#/arbitrum/pool/0x36bf227d6bac96e2ab1ebb5492ecec69c691943f000200000000000000000316