### PR TITLE
chore: Move shak's deployer wallet to emeritus after being removed from gas station.

### DIFF
--- a/extras/signers.json
+++ b/extras/signers.json
@@ -6,7 +6,6 @@
     "xeonus": "0x7019Be4E4eB74cA5F61224FeAf687d2b43998516",
     "danko": "0x200550cAD164E8e0Cb544A9c7Dc5c833122C1438",
     "tritium": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
-    "shakotan": "0x8053484489b110181a6dba0b59dda887e433f470",
     "gosuto": "0x11761c7b08287d9489CD84C04DF6852F5C07107b"
   },
   "blabs_ops": {
@@ -21,7 +20,6 @@
     "zendragon": "0x854B004700885A61107B458f11eCC169A019b764",
     "mikeb": "0xc4591c41e01a7a654b5427f39bbd1dee5bd45d1d",
     "tritium": "0x53a806789BBfd366d9dEB9Cbe5d622089e845fdb",
-    "shakotan": "0x28A6714B06B1241D1F339F9280553F115eCC285B",
     "xeonus": "0x735Fddb3e475e5f7A61Ef674c72a7eDe82D1f493"
   },
   "emergency": {
@@ -58,7 +56,8 @@
   },
   "emeritus": {
     "solarcurve_signer": "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
-    "solarcurve_deployer": "0x6409C2C1aC1B26aaaEF982572efd38412075586D"
+    "solarcurve_deployer": "0x6409C2C1aC1B26aaaEF982572efd38412075586D",
+    "shakotan_deployer": "0x28A6714B06B1241D1F339F9280553F115eCC285B"
   },
   "kyc": {
     "Arbitrum": {


### PR DESCRIPTION
Please do not merge until has has been returned to the gas station.

@SHAKOTN mind sending the gas back to `0x7fb8f5D04b521B6880158819E69538655AABD5c4`

It would also be cool if you could send any L2 gas back to the LM multisig and/or an active deployer (xeonus) on the relevent chains and include tx links here.

