### PR TITLE
ci: enable dependabot updates for workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+# ref: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
enabling dependabot for updates on github actions packages, [just like in the multisig ops repo](https://github.com/BalancerMaxis/multisig-ops/blob/main/.github/dependabot.yaml)