### PR TITLE
Add origin ARB injector

### DIFF
--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -32,7 +32,7 @@
     },
     "maxiKeepers": {
         "gaugeRewardsInjectors": {
-            "arb_rewards_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
+            "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
             "arb_STIP_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
             "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
             "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",

--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -32,7 +32,9 @@
     },
     "maxiKeepers": {
         "gaugeRewardsInjectors": {
-            "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+            "arb_rewards_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
+            "arb_STIP_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+            "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
             "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",
             "usdc_rewards_injector": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
         },


### PR DESCRIPTION
A second $ARB injector to be used by the origin protocol for their injections that have nothing to do with our STIP funds.