### PR TITLE
chore: gen subgraph urls

### DIFF
--- a/bal_addresses/requirements.txt
+++ b/bal_addresses/requirements.txt
@@ -1,5 +1,5 @@
 pathlib>=1.0
-git+https://github.com/BalancerMaxis/bal_tools@v0.0.3
+git+https://github.com/BalancerMaxis/bal_tools
 requests
 pandas
 web3

--- a/bal_addresses/requirements.txt
+++ b/bal_addresses/requirements.txt
@@ -1,5 +1,5 @@
 pathlib>=1.0
-git+https://github.com/BalancerMaxis/bal_tools
+git+https://github.com/BalancerMaxis/bal_tools@v0.0.5
 requests
 pandas
 web3

--- a/gen_subgraph_urls.py
+++ b/gen_subgraph_urls.py
@@ -19,12 +19,11 @@ def main():
             except:
                 continue
             if url:
+                print(url)
                 code = requests.get(url).status_code
                 if code == 200:
                     urls[chain].update({subgraph_type: url})
                 else:
-                    # if code not in urls[chain]:
-                    #     urls[chain][code] = {}
                     urls[chain].update({subgraph_type: {code: url}})
             else:
                 continue

--- a/gen_subgraph_urls.py
+++ b/gen_subgraph_urls.py
@@ -14,7 +14,10 @@ def main():
             urls[chain] = {}
         for subgraph_type in ["core", "gauges", "blocks", "aura"]:
             subgraph = Subgraph(chain)
-            url = subgraph.get_subgraph_url(subgraph_type)
+            try:
+                url = subgraph.get_subgraph_url(subgraph_type)
+            except:
+                continue
             if url:
                 code = requests.get(url).status_code
                 if code == 200:

--- a/outputs/subgraph_urls.json
+++ b/outputs/subgraph_urls.json
@@ -3,66 +3,61 @@
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges",
     "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks",
-    "aura": "https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v2-1"
+    "aura": "https://graph.data.aura.finance/subgraphs/name/aura/aura-mainnet-v2-1"
   },
   "polygon": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon",
     "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks",
-    "aura": {
-      "404": "https://graph.aura.finance/subgraphs/name/aura/aura-polygon-v2-1"
-    }
+    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-polygon"
   },
   "arbitrum": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum",
     "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks",
-    "aura": {
-      "404": "https://graph.aura.finance/subgraphs/name/aura/aura-arbitrum-v2-1"
-    }
+    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-arbitrum"
   },
   "optimism": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-optimism-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism",
-    "aura": {
-      "404": "https://graph.aura.finance/subgraphs/name/aura/aura-optimism-v2-1"
-    }
+    "blocks": "https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics",
+    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-optimism"
   },
   "gnosis": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain",
-    "aura": {
-      "404": "https://graph.aura.finance/subgraphs/name/aura/aura-gnosis-chain-v2-1"
-    }
+    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain"
   },
   "zkevm": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest",
     "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-polygon-zk/version/latest",
     "blocks": "https://api.studio.thegraph.com/query/48427/bleu-polygon-zkevm-blocks/version/latest",
-    "aura": {
-      "400": "https://subgraph.satsuma-prod.com/ab0804deff79/1xhub-ltd/aura-finance-zkevm/api"
-    }
+    "aura": "https://api.studio.thegraph.com/query/69982/aura-finance-zkevm/version/latest"
   },
   "goerli": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli",
-    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks",
-    "aura": "https://graph.aura.finance/subgraphs/name/aura/aura-goerli-v2-1"
+    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks"
   },
   "sepolia": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest",
-    "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-sepolia-beta/version/latest",
-    "aura": "https://graph.aura.finance/subgraphs/name/aura/aura-sepolia-v2-1"
+    "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-sepolia-beta/version/latest"
   },
   "avalanche": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2",
     "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-avalanche",
-    "blocks": "https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks"
+    "blocks": "https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-avalanche/version/v0.0.1/api"
+    }
   },
+  "fantom": {},
   "base": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest",
     "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-base/version/latest",
     "blocks": "https://api.studio.thegraph.com/query/48427/bleu-base-blocks/version/latest",
-    "aura": "https://graph.aura.finance/subgraphs/name/aura/aura-base-v2-1"
-  }
+    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-base"
+  },
+  "mode": {},
+  "linea": {},
+  "fraxtal": {}
 }

--- a/outputs/subgraph_urls.json
+++ b/outputs/subgraph_urls.json
@@ -42,7 +42,6 @@
   "zkevm": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest",
     "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-polygon-zk/version/latest",
-    "blocks": "https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest",
     "aura": {
       "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-zkevm/api"
     }
@@ -53,9 +52,7 @@
     "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks"
   },
   "sepolia": {
-    "core": "https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest",
-    "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-polygon-zk/version/latest",
-    "blocks": "https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest"
+    "core": "https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest"
   },
   "avalanche": {
     "core": "https://api.studio.thegraph.com/query/75376/balancer-avalanche-v2/version/latest",

--- a/outputs/subgraph_urls.json
+++ b/outputs/subgraph_urls.json
@@ -1,37 +1,51 @@
 {
   "mainnet": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges",
-    "blocks": "https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks",
-    "aura": "https://graph.data.aura.finance/subgraphs/name/aura/aura-mainnet-v2-1"
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/ethereum-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-mainnet/api"
+    }
   },
   "polygon": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon",
-    "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks",
-    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-polygon"
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-polygon-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-polygon/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/polygon-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-polygon/api"
+    }
   },
   "arbitrum": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum",
-    "blocks": "https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks",
-    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-arbitrum"
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-arbitrum-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-arbitrum/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/arbitrum-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-arbitrum/api"
+    }
   },
   "optimism": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-optimism-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism",
-    "blocks": "https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics",
-    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-optimism"
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-optimism/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/optimism-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-optimism/api"
+    }
   },
   "gnosis": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain"
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-gnosis-chain-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-gnosis-chain/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/gnosis-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-gnosis/api"
+    }
   },
   "zkevm": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-polygon-zk-v2/version/latest",
     "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-polygon-zk/version/latest",
-    "blocks": "https://api.studio.thegraph.com/query/48427/bleu-polygon-zkevm-blocks/version/latest",
-    "aura": "https://api.studio.thegraph.com/query/69982/aura-finance-zkevm/version/latest"
+    "blocks": "https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest",
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-zkevm/api"
+    }
   },
   "goerli": {
     "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2",
@@ -40,24 +54,38 @@
   },
   "sepolia": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest",
-    "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-sepolia-beta/version/latest"
+    "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-polygon-zk/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest"
   },
   "avalanche": {
-    "core": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2",
-    "gauges": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-avalanche",
-    "blocks": "https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks",
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-avalanche-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-avalanche/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/avalanche-blocks/version/latest",
     "aura": {
-      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-avalanche/version/v0.0.1/api"
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-avalanche/api"
     }
   },
-  "fantom": {},
+  "fantom": {
+    "core": "https://api.studio.thegraph.com/query/73674/beethovenx-v2-fantom/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/fantom-blocks/version/latest"
+  },
   "base": {
     "core": "https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest",
     "gauges": "https://api.studio.thegraph.com/query/24660/balancer-gauges-base/version/latest",
     "blocks": "https://api.studio.thegraph.com/query/48427/bleu-base-blocks/version/latest",
-    "aura": "https://api.thegraph.com/subgraphs/name/aurafinance/aura-finance-base"
+    "aura": {
+      "400": "https://subgraph.satsuma-prod.com/cae76ab408ca/1xhub-ltd/aura-finance-base/api"
+    }
   },
-  "mode": {},
+  "mode": {
+    "core": "https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest",
+    "gauges": "https://api.studio.thegraph.com/query/75376/balancer-gauges-mode/version/latest",
+    "blocks": "https://api.studio.thegraph.com/query/48427/bleu-mode-blocks/version/latest"
+  },
   "linea": {},
-  "fraxtal": {}
+  "fraxtal": {
+    "core": "https://api.goldsky.com/api/public/project_clwhu1vopoigi01wmbn514m1z/subgraphs/balancer-fraxtal-v2/1.0.0/gn",
+    "gauges": "https://api.goldsky.com/api/public/project_clwhu1vopoigi01wmbn514m1z/subgraphs/balancer-gauges-fraxtal/1.0.0/gn",
+    "blocks": "https://api.goldsky.com/api/public/project_clwhu1vopoigi01wmbn514m1z/subgraphs/fraxtal-blocks/1.0.0/gn"
+  }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.9.5"
+VERSION = "0.9.6"
 DESCRIPTION = "Balancer Maxi Addressbook"
 LONG_DESCRIPTION = "Balancer Maxi Addressbook and Balancer Permissions helper"
 
@@ -23,7 +23,7 @@ setup(
         "web3",
         "gql[requests]",
         "requests",
-        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools",
+        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools@v0.0.5",
     ],
     keywords=["python", "first package"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "web3",
         "gql[requests]",
         "requests",
-        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools@v0.0.3",
+        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools",
     ],
     keywords=["python", "first package"],
     classifiers=[


### PR DESCRIPTION
this is after using the latest bal_tools, and thus upgrading to the sdk config as a source for the urls

bumps the package itself to v0.9.6