### PR TITLE
chore: add payees to extras

### DIFF
--- a/extras/signers.json
+++ b/extras/signers.json
@@ -75,9 +75,18 @@
     }
   },
   "contributors-payees": {
+    "xeonus": "0x99AfD53f807766A8B98400B0C785E500c041F32B",
+    "tritium": "0x27e472f2625D6d4913F6cb5b99DAAadb58Da1D93",
+    "mikeb": "0x1b7D0C1d2A730fa791A2937AD75Fef11AeACa3D4",
+    "zen_dragon": "0x7c2eA10D3e5922ba3bBBafa39Dc0677353D2AF17",
+    "gosuto": "0x3f993093c3917Fe7A117f37cFD008775249f59c8",
+    "zekraken": "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae",
     "json": "0xE2A4DE267cdD4fF5ED9Ba13552F5c624b12db9b2",
     "lipman": "0x72658e9A5c55371A5e80559B8E07AbC14F212120",
     "hyferion": "0xE24fA83aF4dDd6d3e448908ed3F931f0A23a6096",
     "jalbrekt": "0xA0c60A3Bf0934869f03955f3431E044059B03E62"
+  },
+  "external-payees": {
+    "discord-antiscam-bot": "0x8c42138C925d1049EC6B29F1EcF817b1628e54Ba"
   }
 }


### PR DESCRIPTION
this was already reviewed in #359 but put in the wrong file (`outputs/`)