### PR TITLE
fix: only run for prod chains and raise on errors

### DIFF
--- a/gen_pools_and_gauges.py
+++ b/gen_pools_and_gauges.py
@@ -108,31 +108,20 @@ def main():
 
     with open("extras/chains.json", "r") as f:
         chains = json.load(f)
-    for chain in chains["CHAIN_IDS_BY_NAME"]:
-        print(chain)
-        if chain == "fantom":
-            # not a balancer native chain
-            continue
+    for chain in chains["BALANCER_PRODUCTION_CHAINS"]:
+        print(f"Generating pools and gauges for {chain}...")
         gauge_info = BalPoolsGauges(chain)
         # pools
         # TODO: consider moving to query object??
-        try:
-            result = process_query_swap_enabled_pools(query_swap_enabled_pools(chain))
-            if result:
-                pools[chain] = result
-        except Exception as e:
-            print(f"Error using core subgraph for {chain}, skipping: {e}")
-            pools[chain] = {}
+        result = process_query_swap_enabled_pools(query_swap_enabled_pools(chain))
+        if result:
+            pools[chain] = result
         # gauges
-        try:
-            result = process_query_preferential_gauges(
-                gauge_info.query_preferential_gauges()
-            )
-            if result:
-                gauges[chain] = result
-        except Exception as e:
-            print(f"Error using gauge subgraph for {chain}, skipping: {e}")
-            gauges[chain] = {}
+        result = process_query_preferential_gauges(
+            gauge_info.query_preferential_gauges()
+        )
+        if result:
+            gauges[chain] = result
         # cache mainnet BalPoolsGauges
         if chain == "mainnet":
             gauge_info_mainnet = gauge_info


### PR DESCRIPTION
last run failed to retrieve pools and gauges for ethereum and gnosis, but the error was caught and the ci workflow continued (https://github.com/BalancerMaxis/bal_addresses/actions/runs/10252037228/job/28361482279)
```
mainnet
Error using core subgraph for mainnet, skipping: 429 Client Error: Too Many Requests for url: https://api.studio.thegraph.com/query/75376/balancer-v2/version/latest
polygon
arbitrum
optimism
gnosis
Error using core subgraph for gnosis, skipping: 504 Server Error: Gateway Timeout for url: https://api.studio.thegraph.com/query/75376/balancer-gnosis-chain-v2/version/latest
zkevm
goerli
Error using core subgraph for goerli, skipping: 410 Client Error: Gone for url: https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2
Error using gauge subgraph for goerli, skipping: 410 Client Error: Gone for url: https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli
sepolia
Error using gauge subgraph for sepolia, skipping: Invalid URL 'None': No scheme supplied. Perhaps you meant https://None?
avalanche
fantom
base
mode
fraxtal
```
this results in a pr which removes all pools/gauges it couldnt retrieve, which i think should not occur ever (https://github.com/BalancerMaxis/bal_addresses/pull/400)

furthermore, the subgraphs for the testnets are not deployed and/or unreliable

suggesting here to only run pools and gauges for production chains, and raise (thus fail the workflow) if data for these chains cannot be retrieved successfully