### PR TITLE
Adding-Stakewise-&-Gyro_Arbitrum-Distributors

### DIFF
--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -1,94 +1,98 @@
 {
-    "zero": {
-        "zero": "0x0000000000000000000000000000000000000000"
-    },
+  "zero": {
+    "zero": "0x0000000000000000000000000000000000000000"
+  },
   "balancer": {
     "EventEmitter": "0x8f32D631093B5418d0546f77442c5fa66187E59D"
   },
-    "tokens": {
-        "ARB": "0x912CE59144191C1204E64559FE8253a0e49E6548",
-        "BADGER": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
-        "WBTC": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
-        "USDC": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-        "CRV": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
-        "SUSHI": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
-        "renBTC": "0xdbf31df14b66535af65aac99c32e9ea844e14501",
-        "WETH": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
-        "USDT": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-        "stkauraBAL": "0x4EA9317D90b61fc28C418C247ad0CA8939Bbb0e9",
-        "LINK": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
-        "LDO": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60"
+  "tokens": {
+    "ARB": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+    "BADGER": "0xBfa641051Ba0a0Ad1b0AcF549a89536A0D76472E",
+    "WBTC": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+    "USDC": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+    "CRV": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+    "SUSHI": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+    "renBTC": "0xdbf31df14b66535af65aac99c32e9ea844e14501",
+    "WETH": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+    "USDT": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+    "stkauraBAL": "0x4EA9317D90b61fc28C418C247ad0CA8939Bbb0e9",
+    "LINK": "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+    "LDO": "0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60"
+  },
+  "across": {
+    "spoke_pool": "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C"
+  },
+  "chainlink": {
+    "keeper_registry_v2_1": "0x37D9dC70bfcd8BC77Ec2858836B923c560E891D1",
+    "keeper_registrar_v2_1": "0x86EFBD0b6736Bed994962f9797049422A3A8E8Ad",
+    "keeper_registry": "0x75c0530885F385721fddA23C539AF3701d6183D4",
+    "keeper_registrar": "0x4F3AF332A30973106Fe146Af0B4220bBBeA748eC"
+  },
+  "sushi": {
+    "router": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506"
+  },
+  "swapr": {
+    "router": "0x530476d5583724A89c8841eB6Da76E7Af4C0F17E"
+  },
+  "arbitrum": {
+    "node": "0x00000000000000000000000000000000000000C8",
+    "gateway_router": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933"
+  },
+  "maxiKeepers": {
+    "gaugeRewardsInjectors": {
+      "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+      "arb_STIP_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+      "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
+      "arb_aave_injector": "0xE23eb92f0C76bF47f77F80D144e30F31b98450A9",
+      "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",
+      "usdc_rewards_injector": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
     },
-    "across": {
-        "spoke_pool": "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C"
+    "one_inch": {
+      "settlement": "0xad3b67bca8935cb510c8d18bd45f0b94f54a968f"
     },
-    "chainlink": {
-        "keeper_registry_v2_1": "0x37D9dC70bfcd8BC77Ec2858836B923c560E891D1",
-        "keeper_registrar_v2_1": "0x86EFBD0b6736Bed994962f9797049422A3A8E8Ad",
-        "keeper_registry": "0x75c0530885F385721fddA23C539AF3701d6183D4",
-        "keeper_registrar": "0x4F3AF332A30973106Fe146Af0B4220bBBeA748eC"
-    },
-    "sushi": {
-        "router": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506"
-    },
-    "swapr": {
-        "router": "0x530476d5583724A89c8841eB6Da76E7Af4C0F17E"
-    },
-    "arbitrum": {
-        "node": "0x00000000000000000000000000000000000000C8",
-        "gateway_router": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933"
-    },
-    "maxiKeepers": {
-        "gaugeRewardsInjectors": {
-            "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
-            "arb_STIP_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
-            "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
-            "arb_aave_injector": "0xE23eb92f0C76bF47f77F80D144e30F31b98450A9",
-            "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",
-            "usdc_rewards_injector": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
-        },
-        "one_inch": {
-            "settlement": "0xad3b67bca8935cb510c8d18bd45f0b94f54a968f"
-        },
-        "mimic": {
-            "smartvault": "0x94Dd9C6152a2A0BBcB52d3297b723A6F01D5F9f7",
-            "smartVaultV3": "0x9e5D6427D2cdaDC68870197b099C2Df535Ec3c97",
-            "claimer": "0xdF818E63341767d5F5A9827088f1892e9C604A2D",
-            "bptSwapper": "0x6030331C9225Ee5ae3F3D08FBD19e8bF053dF498",
-            "oneinchSwapper": "0xd712A863766dE7e7cA13289A97997E01832A6571",
-            "paraswapSwapper": "0x95676AaEcD59B19C5B79008F86d3A291628b0947"
-        }
-    },
-    "hidden_hand2": {
-        "bribe_vault": "0x8d89593c199Cb763bDEF04529F978f82503E4669",
-        "aura_briber": "0x928b06229a3f4Bc7806d80Fe54e48E777BB74536"
-    },
+    "mimic": {
+      "smartvault": "0x94Dd9C6152a2A0BBcB52d3297b723A6F01D5F9f7",
+      "smartVaultV3": "0x9e5D6427D2cdaDC68870197b099C2Df535Ec3c97",
+      "claimer": "0xdF818E63341767d5F5A9827088f1892e9C604A2D",
+      "bptSwapper": "0x6030331C9225Ee5ae3F3D08FBD19e8bF053dF498",
+      "oneinchSwapper": "0xd712A863766dE7e7cA13289A97997E01832A6571",
+      "paraswapSwapper": "0x95676AaEcD59B19C5B79008F86d3A291628b0947"
+    }
+  },
+  "hidden_hand2": {
+    "bribe_vault": "0x8d89593c199Cb763bDEF04529F978f82503E4669",
+    "aura_briber": "0x928b06229a3f4Bc7806d80Fe54e48E777BB74536"
+  },
 
-    "maxiVestingContracts": {
-        "factory": "0x7BBAc709a9535464690A435ca7361256496f13Ce",
-        "Tritium": "0x2b03b15E4A26D858DD594649988255eCEb832787",
-        "shak": "0x3e7EC248fd5BE044C0efcE9fAA778AC374350efc",
-        "Xeonus": "0xCE49aeFDDdDBa966cd69e6A4670f4F795F577264",
-        "zekraken": "0x5C8260f4eB66eC847018BBC5f68694864eF094Fe",
-        "Zen Dragon": "0x2466f62D52005AaB7A8F637CC3152361D4CC210c",
-        "Mike B": "0x81DE849AdB5883d089cdFd66bB399b4Af74a16bb",
-        "Danko": "0x2304488F0eddF15227C21b021739448B51E791C0",
-        "Dubstard": "0x01B894622C7aa890d758C8a0E8156480F0Fa5f6C",
-        "gosuto": "0xd411b886e96291b089273a5835D2BE4406700352",
-        "lipman": "0xB209a59A9F3CC7FA5A25dF152a01f9dF8B969A3a"
-    },
-    "karpatkey": {
-        "delegate_msig": "0x583E3EDc26E1B8620341bce90547197bfE2c1ddD"
-    },
-    "TreasuryExtentions": {
-        "AURA_ARB_BAL_LP_BIP_322": "0x8D803f7f7e26E586ee90E5A872cf7830e21f7727"
-    },
-    "gyro": {
-        "L2GydDistributor": "0x401937B787277CB0680835303f013cf4d3D1cB14",
-        "foundation_multisig": "0x823F70044351b213083F0ABc2169F95E2731064E"
-    },
+  "maxiVestingContracts": {
+    "factory": "0x7BBAc709a9535464690A435ca7361256496f13Ce",
+    "Tritium": "0x2b03b15E4A26D858DD594649988255eCEb832787",
+    "shak": "0x3e7EC248fd5BE044C0efcE9fAA778AC374350efc",
+    "Xeonus": "0xCE49aeFDDdDBa966cd69e6A4670f4F795F577264",
+    "zekraken": "0x5C8260f4eB66eC847018BBC5f68694864eF094Fe",
+    "Zen Dragon": "0x2466f62D52005AaB7A8F637CC3152361D4CC210c",
+    "Mike B": "0x81DE849AdB5883d089cdFd66bB399b4Af74a16bb",
+    "Danko": "0x2304488F0eddF15227C21b021739448B51E791C0",
+    "Dubstard": "0x01B894622C7aa890d758C8a0E8156480F0Fa5f6C",
+    "gosuto": "0xd411b886e96291b089273a5835D2BE4406700352",
+    "lipman": "0xB209a59A9F3CC7FA5A25dF152a01f9dF8B969A3a"
+  },
+  "karpatkey": {
+    "delegate_msig": "0x583E3EDc26E1B8620341bce90547197bfE2c1ddD"
+  },
+  "TreasuryExtentions": {
+    "AURA_ARB_BAL_LP_BIP_322": "0x8D803f7f7e26E586ee90E5A872cf7830e21f7727"
+  },
+  "gyro": {
+    "L2GydDistributor": "0x401937B787277CB0680835303f013cf4d3D1cB14",
+    "foundation_multisig": "0x823F70044351b213083F0ABc2169F95E2731064E",
+    "Gyro_ARB_Aave_safe": "0xDB9F47800bA9CDd9f99815Bc02dD0Aa47AbffE88"
+  },
   "beefy": {
     "wstETH-weETH_ECLP_boost": "0x6B970F0D1F0255b8E0B1c4515Ae827931b32312C",
     "wstETH-ezETH_boost": "0xfcF293AFa58fa277935eddAa44E0f782EC41B09B"
+  },
+  "stakewise": {
+    "SWISE_Distributor_Safe": "0x2685C0e39EEAAd383fB71ec3F493991d532A87ae"
   }
 }


### PR DESCRIPTION
Per recent request from Gyroscope this safe 0xDB9F47800bA9CDd9f99815Bc02dD0Aa47AbffE88 will distribute ARB to Gyro gauges claimed from AAVE rehype pools.

Per Stakewise this safe: 0x2685C0e39EEAAd383fB71ec3F493991d532A87ae will distribute SWISE token 0x4026AFfABd9032bCC87Fa05C02F088905f3dC09B on Arbitrum, starting with one pool.

https://app.balancer.fi/#/arbitrum/pool/0x42f7cfc38dd1583ffda2e4f047f4f6fa06cefc7c000000000000000000000553