### PR TITLE
Adding-Stakewise-SWISE-Distributor-Gnosis

### DIFF
--- a/extras/gnosis.json
+++ b/extras/gnosis.json
@@ -24,5 +24,8 @@
         "gaugeRewardsInjectors": {
             "usdc_rewards_injector": "0x87c921be1fd8ee7E5eda4394aDB849DB72847aE9"
         }
-    }
+    },
+    "stakewise": {
+        "SWISE_Distributor_EOA": "0x2685C0e39EEAAd383fB71ec3F493991d532A87ae"
+      }
 }


### PR DESCRIPTION
Double checking with Stakewise team; but for now we have this request calling out this address.

<img width="531" alt="image" src="https://github.com/user-attachments/assets/73f7e0ce-3882-49bf-b1a5-229f4f3aafdf">
