### PR TITLE
add paladin distributor and HH bal briber

### DIFF
--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -65,7 +65,8 @@
   },
   "hidden_hand2": {
     "bribe_vault": "0x8d89593c199Cb763bDEF04529F978f82503E4669",
-    "aura_briber": "0x928b06229a3f4Bc7806d80Fe54e48E777BB74536"
+    "aura_briber": "0x928b06229a3f4Bc7806d80Fe54e48E777BB74536",
+    "bal_briber": "0xA8214b4Fb98936Ed45463956aFD24a862cC86Dc1"
   },
   "maxiVestingContracts": {
     "factory": "0x7BBAc709a9535464690A435ca7361256496f13Ce",
@@ -96,7 +97,8 @@
     "wstETH-ezETH_boost": "0xfcF293AFa58fa277935eddAa44E0f782EC41B09B"
   },
   "paladin": {
-    "QuestBoardV2Sidechain": "0x997523eF97E0b0a5625Ed2C197e61250acF4e5F1"
+    "QuestBoardV2Sidechain": "0x997523eF97E0b0a5625Ed2C197e61250acF4e5F1",
+    "DistributorV2": "0xB5757D5D93a26EaA3Bc6b0b25cb2364bE8d5b90E"
   },
   "circle": {
     "message_transmitter": "0xC30362313FBBA5cf9163F0bb16a0e01f01A896ca"

--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -98,7 +98,8 @@
   },
   "paladin": {
     "QuestBoardV2Sidechain": "0x997523eF97E0b0a5625Ed2C197e61250acF4e5F1",
-    "DistributorV2": "0xB5757D5D93a26EaA3Bc6b0b25cb2364bE8d5b90E"
+    "DistributorV1": "0xB5757D5D93a26EaA3Bc6b0b25cb2364bE8d5b90E",
+    "DistributorV2": "0x5E90Fb83Bc3B733D028454f7372A80b2977d7e6a"
   },
   "circle": {
     "message_transmitter": "0xC30362313FBBA5cf9163F0bb16a0e01f01A896ca"

--- a/extras/mainnet.json
+++ b/extras/mainnet.json
@@ -204,7 +204,8 @@
     "paladin": {
         "QuestBoardLatest": "0xfEb352930cA196a80B708CDD5dcb4eCA94805daB",
         "QuestBoardV2": "0xf0CeABf99Ddd591BbCC962596B228007eD4624Ae",
-        "QuestBoardV2_1": "0xfEb352930cA196a80B708CDD5dcb4eCA94805daB"
+        "QuestBoardV2_1": "0xfEb352930cA196a80B708CDD5dcb4eCA94805daB",
+        "DistributorV2": "0x1F7b4Bf0CD21c1FBC4F1d995BA0608fDfC992aF4"
     },
     "safe_harbor": {
         "registry": "0x8f72fcf695523A6FC7DD97EafDd7A083c386b7b6"


### PR DESCRIPTION
adding addrs used in: https://github.com/BalancerMaxis/multisig-ops/pull/1488/files#diff-effdea1184a8b4481c4beff6194ed518e3dfd296ef8548635c8f27deef3ca38e

[arbi HH bal briber](https://arbiscan.io/address/0xA8214b4Fb98936Ed45463956aFD24a862cC86Dc1)
[arbi paladin distributor](https://arbiscan.io/address/0xB5757D5D93a26EaA3Bc6b0b25cb2364bE8d5b90E)
[mainnet paladin distributor](https://etherscan.io/address/0x1F7b4Bf0CD21c1FBC4F1d995BA0608fDfC992aF4)
