### PR TITLE
Add mainnet NET injector for Paladin/Nektar.

### DIFF
--- a/extras/mainnet.json
+++ b/extras/mainnet.json
@@ -151,7 +151,8 @@
     "LZRateProviderPoker": "0xdDd5FF0E581f097573B13f247F6BE736f602F839",
     "gaugeRewardsInjectors": {
       "Balancer_BAL": "0x5a18FE4D7a2bd5A39CCa4F9D05D073F21FAE28EE",
-      "usdc": "0x80D737BF3973D92a1B5FC4b166F89cb9e7445632"
+      "usdc": "0x80D737BF3973D92a1B5FC4b166F89cb9e7445632",
+      "net": "0x9BE5CE14d1FD02517682aeC14c7162328E9e386e"
     }
   },
   "gelatoW3f": {


### PR DESCRIPTION
As per request for Figue in the Paladin Partner chat:

Chainlink Automation: https://automation.chain.link/mainnet/1162209358248010138892593534629421720784058705808131142117019239632224091812

Still owned by Tritiums deployer,  but can be taken over by omnichain safe with an acceptOwnership. 