### PR TITLE
chore: bump bal tools to v.0.1.18

### DIFF
--- a/bal_addresses/requirements.txt
+++ b/bal_addresses/requirements.txt
@@ -1,5 +1,5 @@
 pathlib>=1.0
-git+https://github.com/BalancerMaxis/bal_tools.git@v0.1.17
+git+https://github.com/BalancerMaxis/bal_tools.git@v0.1.18
 requests
 pandas
 web3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "setuptools>=42",
         "wheel",
         "pathlib>=1.0",
-        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools.git@v0.1.17",
+        "bal_tools @ git+https://github.com/BalancerMaxis/bal_tools.git@v0.1.18",
         "requests",
         "pandas",
         "web3",


### PR DESCRIPTION
https://github.com/BalancerMaxis/bal_tools/releases/tag/v0.1.18