### PR TITLE
chore: deprecate old v1 injectors

### DIFF
--- a/extras/arbitrum.json
+++ b/extras/arbitrum.json
@@ -46,12 +46,15 @@
   },
   "maxiKeepers": {
     "gaugeRewardsInjectors": {
-      "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
       "arb_STIP_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
-      "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
       "arb_aave_injector": "0xE23eb92f0C76bF47f77F80D144e30F31b98450A9",
-      "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",
-      "usdc_rewards_injector": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
+      "_deprecated": {
+        "arb_rewards_injector": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+        "arb_origin_injector": "0xdcDAFd9E4cc10Ec5dCf1411eE2EdBc4E204aE9Bf",
+        "fox_rewards_injector": "0xc085bD4cEd17015eAe366a6d1Cd095a2F6fD0B6D",
+        "usdc_rewards_injector": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
+
+      }
     },
     "injectorV2": {
       "factory": "0x6142582f8946bf192a4f80ed643a5856d18a7060",

--- a/extras/avalanche.json
+++ b/extras/avalanche.json
@@ -20,10 +20,12 @@
     "gaugeRewardsInjectors": {
       "avax": "0xf23d8342881edecced51ea694ac21c2b68440929",
       "usdc": "0x099D7767eC64Ac33C076f1e3Eb3DC24D08FA86A5",
-      "qi": "0x47c97d8Eaa5D84aE25df9c92290B40eD252E75eE",
-      "yyavax": "0x95008946F2773f24588AEEE44d643016381265FF",
-      "ggp": "0x39C441560e83e02452e4B4789934aC031A85c1d5",
-      "ankr": "0x10087761Ebd0Da939d2123A0B18D69F11f5Ea67f"
+      "_deprecated": {
+        "qi": "0x47c97d8Eaa5D84aE25df9c92290B40eD252E75eE",
+        "yyavax": "0x95008946F2773f24588AEEE44d643016381265FF",
+        "ggp": "0x39C441560e83e02452e4B4789934aC031A85c1d5",
+        "ankr": "0x10087761Ebd0Da939d2123A0B18D69F11f5Ea67f"
+      }
     },
     "injectorV2": {
       "factory": "0x6142582f8946bf192a4f80ed643a5856d18a7060",

--- a/extras/base.json
+++ b/extras/base.json
@@ -17,7 +17,9 @@
     "gasStation": "0x34a265e1EBCb31586293eb2D2f94c6ff2f920340",
     "gaugeRewardsInjectors": {
       "usdc": "0xA6E7840Fc8193cFeBDdf177fa410038E5DD08f7A",
-      "gold": "0x79D0F97D4D8c1Dd30b1Ea09746dB8847036AD92d"
+      "_deprecated": {
+        "gold": "0x79D0F97D4D8c1Dd30b1Ea09746dB8847036AD92d"
+      }
     },
     "injectorV2": {
       "factory": "0x6142582f8946bf192a4f80ed643a5856d18a7060",

--- a/extras/mainnet.json
+++ b/extras/mainnet.json
@@ -158,7 +158,9 @@
     "gaugeRewardsInjectors": {
       "Balancer_BAL": "0x5a18FE4D7a2bd5A39CCa4F9D05D073F21FAE28EE",
       "usdc": "0x80D737BF3973D92a1B5FC4b166F89cb9e7445632",
-      "net": "0x9BE5CE14d1FD02517682aeC14c7162328E9e386e"
+      "_deprecated": {
+        "net": "0x9BE5CE14d1FD02517682aeC14c7162328E9e386e"
+      }
     },
     "injectorV2": {
       "factory": "0x6142582f8946bf192a4f80ed643a5856d18a7060",


### PR DESCRIPTION
- move some (but not all) of v1 injectors to a deprecated subcategory
- keep some token injectors as they might be used in the future (e.g. ARB STIP injector)