### PR TITLE
ci: use bal tools with unpinned pandas

### DIFF
--- a/bal_addresses/requirements.txt
+++ b/bal_addresses/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/BalancerMaxis/bal_tools.git#egg=bal_tools
+git+https://github.com/BalancerMaxis/bal_tools.git@ci/unpin-pandas#egg=bal_tools


### PR DESCRIPTION
hoping this will prevent manual building of pandas package through wheel, as we saw here: https://github.com/BalancerMaxis/bal_addresses/actions/runs/14128795298/job/39584466516