### PR TITLE
fix: ignore circles backing pools

### DIFF
--- a/gen_pools_and_gauges.py
+++ b/gen_pools_and_gauges.py
@@ -8,6 +8,8 @@ from bal_tools import BalPoolsGauges
 def process_query_pools(result) -> dict:
     flattened_result = []
     for pool_data in result:
+        if pool_data.symbol.startswith("circlesBackingLBP"):
+            continue
         flattened_result.append(
             {"address": pool_data.address, "symbol": pool_data.symbol}
         )


### PR DESCRIPTION
started getting collisions: https://github.com/BalancerMaxis/bal_addresses/actions/runs/15462136981/job/43525693377
```
Generating pools and gauges for gnosis...
Found duplicate symbols!
                                        address                        symbol
120  0x25e1f4fc31a627979e0940ef59c0158aa84f8c0f  circlesBackingLBP-s-CRC-25e1
213  0x25e17285e08749b5f9e32ac8137f29cfc71edc61  circlesBackingLBP-s-CRC-25e1
```