### PR TITLE
Chore: add Gyroscope managed GYD injector on mainnet

### DIFF
--- a/extras/mainnet.json
+++ b/extras/mainnet.json
@@ -169,7 +169,8 @@
     "injectorV2": {
       "factory": "0x6142582f8946bf192a4f80ed643a5856d18a7060",
       "mockLogic": "0x747c4f7d3fc02b7975779effdf5d1c77105109cb",
-      "GEAR": "0xfa7b21b30325dbbd4a71ee2b2ede74a7d8a2c0e4"
+      "GEAR": "0xfa7b21b30325dbbd4a71ee2b2ede74a7d8a2c0e4",
+      "GYD-Gyro": "0xdBfeEFAB1833c5219a4E1Ce9Cfa2466E038CAA83"
     }
   },
   "gelatoW3f": {


### PR DESCRIPTION
- add mainnet GYD label, injector is managed by Gyroscope
- Owner: 0xbA53D5bF49362Ec2907B12DB3468Bb5Be16F5704 (Gyro safe)