### PR TITLE
feat: add hyperevm emergency safe

### DIFF
--- a/extras/multisigs.json
+++ b/extras/multisigs.json
@@ -129,7 +129,8 @@
     "maxi_omni": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
   },
   "hyperevm": {
-    "maxi_omni": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+    "maxi_omni": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "emergency": "0x44613a28347206F5E26C1B8Db7Dc73f450219746"
   },
   "bnb": {
     "_deprecated": {


### PR DESCRIPTION
- Set up new Emergency subDAO safe with same signer set as with other safes according to [signer set](https://github.com/BalancerMaxis/bal_addresses/blob/56669ba1df228e24051a13419d4e114baf513548/extras/signers.json#L39) with threshold 4/7 
- Safe UI: https://safe.onchainden.com/home?safe=hyperevm:0x44613a28347206F5E26C1B8Db7Dc73f450219746