### PR TITLE
chore: clean-up signer set

### DIFF
--- a/extras/signers.json
+++ b/extras/signers.json
@@ -1,10 +1,8 @@
 {
   "maxis": {
-    "zendragon": "0x7c2eA10D3e5922ba3bBBafa39Dc0677353D2AF17",
     "zekraken": "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae",
     "mikeb": "0xc4591c41e01a7a654B5427f39Bbd1dEe5bD45D1D",
     "xeonus": "0x7019Be4E4eB74cA5F61224FeAf687d2b43998516",
-    "danko": "0x200550cAD164E8e0Cb544A9c7Dc5c833122C1438",
     "jalbrekt": "0x119de05a00BD4e75C4aD6041b82d7afa984aB1B9",
     "gosuto": "0x11761c7b08287d9489CD84C04DF6852F5C07107b",
     "raq": "0x960bE2d20669E1b2bfc38dBC92bf1c440Cc60F9d"
@@ -19,7 +17,6 @@
     "Fabio": "0x90347b9CC81a4a28aAc74E8B134040d5ce2eaB6D"
   },
   "maxi_deployers": {
-    "zendragon": "0x854B004700885A61107B458f11eCC169A019b764",
     "mikeb": "0xc4591c41e01a7a654b5427f39bbd1dee5bd45d1d",
     "xeonus": "0x735Fddb3e475e5f7A61Ef674c72a7eDe82D1f493",
     "jalbrekt": "0xCD0d67924344aC36095812E04449795d9F0B8F3c",
@@ -77,12 +74,18 @@
     "solarcurve_signer": "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
     "tritium_signer": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
     "tritium-ops_signer": "0x7b183340d531cEd66d7F18fE171Df4c6A3cC61A4",
+    "danko_signer": "0x200550cAD164E8e0Cb544A9c7Dc5c833122C1438",
     "solarcurve_deployer": "0x6409C2C1aC1B26aaaEF982572efd38412075586D",
     "shakotan_deployer": "0x28A6714B06B1241D1F339F9280553F115eCC285B",
     "tritium_deployer": "0x53a806789BBfd366d9dEB9Cbe5d622089e845fdb",
+    "zendragon_deployer": "0x854B004700885A61107B458f11eCC169A019b764",
     "nico_emergency": "0x815d654E930E840D0E0Ee1B18FFc8Fb4ddA4c6B3",
     "Markus_emergency": "0x6bB4720473d4D7133f944785e5EE1A650C07f34e",
-    "zekraken_payee": "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae"
+    "zekraken_payee": "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae",
+    "tritium_payee": "0x27e472f2625D6d4913F6cb5b99DAAadb58Da1D93",
+    "zendragon_payee": "0xE743449D33F2F330A46dbC050565239F5dF8805A",
+    "hyferion_payee": "0xE24fA83aF4dDd6d3e448908ed3F931f0A23a6096",
+    "lipman_payee": "0x72658e9A5c55371A5e80559B8E07AbC14F212120"
   },
   "kyc": {
     "Arbitrum": {
@@ -94,14 +97,10 @@
   },
   "contributors-payees": {
     "xeonus": "0x99AfD53f807766A8B98400B0C785E500c041F32B",
-    "tritium": "0x27e472f2625D6d4913F6cb5b99DAAadb58Da1D93",
     "mikeb": "0x1b7D0C1d2A730fa791A2937AD75Fef11AeACa3D4",
-    "zen_dragon": "0xE743449D33F2F330A46dbC050565239F5dF8805A",
     "gosuto": "0x3f993093c3917Fe7A117f37cFD008775249f59c8",
     "zekraken": "0x6c328C0A17D0F0E2f2AE8286823743e0aF8D4cCB",
     "json": "0xE2A4DE267cdD4fF5ED9Ba13552F5c624b12db9b2",
-    "lipman": "0x72658e9A5c55371A5e80559B8E07AbC14F212120",
-    "hyferion": "0xE24fA83aF4dDd6d3e448908ed3F931f0A23a6096",
     "jalbrekt": "0xA0c60A3Bf0934869f03955f3431E044059B03E62",
     "raq": "0x734f9B824a9bBb49a6872F1781EE540435Ce3488",
     "recon": "0xDa7F9BDc9e8c02a054cF71c90f20707c4C20cA5B"


### PR DESCRIPTION
- move all inactive signers and payees to emeritus category
- keep zen in emergency signer group, remove from others