### PR TITLE
chore: add aura locker v2 to mainnet

### DIFF
--- a/extras/mainnet.json
+++ b/extras/mainnet.json
@@ -76,6 +76,7 @@
   "helpers": {
     "balance_checker": "0xe92261c2D64C363109c36a754A87107142e61b72",
     "vlaura_relocker_module": "0xfD20C63554A9916816dC5e5Df596A0333185F263",
+    "vlaura_relocker_module_v2": "0xF7a15f01FcDaAf6681A11Ab851aEbA7deD3dd90D",
     "hypernative_cspv6_pause_module": "0xbaEa4E4A47a3b88e03C003DE6Baf8F5404DA9d56",
     "otc_escrow_bal_cow": "0xdBe554ee86FEb0b1c0ac4743503D46cbDF0e8B54",
     "rebalancerForPool": "0x3FBbB48ad78051982688a5a2Bc45eB6E2046a136"


### PR DESCRIPTION
just deployed: https://etherscan.io/tx/0x91f9d6dd5cd57f1e08c7754b2b2559fde1b807a0a3120b6f66e9feab4462343d. see https://github.com/onchainification/aura_locker_v2/pull/3.

closes https://github.com/BalancerMaxis/multisig-ops/issues/2069