### PR TITLE
ci: use github app

### DIFF
--- a/.github/workflows/generate_addressbooks.yaml
+++ b/.github/workflows/generate_addressbooks.yaml
@@ -43,6 +43,7 @@ jobs:
           git add -A
 
       - name: pull-request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -51,3 +52,9 @@ jobs:
           branch: "gha-addressbook"
           reviewers: "gosuto-inzasheru"
           labels: "Automatic"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --auto --merge ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/generate_addressbooks.yaml
+++ b/.github/workflows/generate_addressbooks.yaml
@@ -11,10 +11,18 @@ jobs:
     env:
       GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Python
         uses: actions/setup-python@v6
@@ -37,6 +45,7 @@ jobs:
       - name: pull-request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Scheduled update to addressbooks deployments"
           title: "Scheduled update to addressbooks deployments"
           branch: "gha-addressbook"

--- a/.github/workflows/generate_core_pools.yaml
+++ b/.github/workflows/generate_core_pools.yaml
@@ -10,10 +10,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Python
         uses: actions/setup-python@v6
@@ -30,6 +38,7 @@ jobs:
       - name: pull-request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Scheduled updates to core pools JSON"
           title: "Scheduled updates to core pools JSON"
           branch: "gha-corepools"

--- a/.github/workflows/generate_core_pools.yaml
+++ b/.github/workflows/generate_core_pools.yaml
@@ -36,6 +36,7 @@ jobs:
           git add -A
 
       - name: pull-request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -44,3 +45,9 @@ jobs:
           branch: "gha-corepools"
           reviewers: "gosuto-inzasheru"
           labels: "Core Pools"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --auto --merge ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/generate_permissions.yaml
+++ b/.github/workflows/generate_permissions.yaml
@@ -11,10 +11,18 @@ jobs:
     env:
       DRPC_KEY: ${{ secrets.DRPC_KEY }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Python
         uses: actions/setup-python@v6
@@ -31,6 +39,7 @@ jobs:
       - name: pull-request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Scheduled update to active permissions"
           title: "Scheduled update to active permissions"
           branch: "gha-permissions"

--- a/.github/workflows/generate_permissions.yaml
+++ b/.github/workflows/generate_permissions.yaml
@@ -37,6 +37,7 @@ jobs:
           git add -A
 
       - name: pull-request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -45,3 +46,9 @@ jobs:
           branch: "gha-permissions"
           reviewers: "gosuto-inzasheru"
           labels: "Automatic"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --auto --merge ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
github-actions[bot] cannot trigger other workflows as a security measure. needs either pat (personal token) or github app

this implements the latter

see https://github.com/organizations/BalancerMaxis/settings/installations/85217153