### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate_core_pools.yaml
+++ b/.github/workflows/generate_core_pools.yaml
@@ -1,4 +1,6 @@
 name: Generate Core Pools JSON
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/13](https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/13)

The fix consists of adding an explicit `permissions` block to the workflow, specifying the minimum necessary permissions for the job. As all privileged operations are performed via a GitHub App token, the workflow itself likely only needs read-only access to repository contents for other steps. This is best achieved by adding `permissions: { contents: read }` at the workflow root (after the `name` and before/in conjunction with `on:`), so that all jobs inherit these restricted permissions unless explicitly overridden. If other permissions are later needed, those can be added selectively. To fix, insert the `permissions:` block with appropriate indentation at the top of `.github/workflows/generate_core_pools.yaml` after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
