### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate_addressbooks.yaml
+++ b/.github/workflows/generate_addressbooks.yaml
@@ -1,4 +1,7 @@
 name: Generate Addressbooks Deployments
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/12](https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/12)

To fix the problem, we should add a top-level `permissions:` key to the workflow YAML or, if finer control is needed, at the job level. In this case, top-level permissions are simpler since there is only one job.  
Examining the workflow's actions:
- It checks out code using a generated GitHub App token (not `GITHUB_TOKEN`), but actions like `create-pull-request` and merging PRs will require write access to pull requests.
- The minimal necessary permissions appear to be:
  - `contents: read` (to pull source code, although this is done with a token)
  - `pull-requests: write` for creating/merging pull requests

Therefore, adding
```yaml
permissions:
  contents: read
  pull-requests: write
```
after the `name: ...` line and before `on:` will constrain the `GITHUB_TOKEN` to the fewest set of permissions needed for this workflow. If later jobs/actions require more, this block can be adjusted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
