### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/5](https://github.com/BalancerMaxis/bal_addresses/security/code-scanning/5)

The correct fix is to add a `permissions` block limiting the GITHUB_TOKEN to read-only access for repository contents. This can be set at the root of the workflow (applies to all jobs) or at the job level (inside the `build` job). Adding it at the root is most robust, as it guarantees all jobs inherit these least privileges unless they request more. Since you have only shared this file, all changes should be within `.github/workflows/test.yml`. The required fix is to insert the following lines right after the `name` field (and before `on:`), or if you prefer, inside the `build` job (as a sibling to `runs-on`, `timeout-minutes`, etc.), but the root-level is the usual recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
