### PR TITLE
chore: handle pool symbol collisions

### DIFF
--- a/gen_pools_and_gauges.py
+++ b/gen_pools_and_gauges.py
@@ -19,8 +19,8 @@ def process_query_pools(result) -> dict:
     # assert no duplicate addresses exist
     assert len(df["address"].unique()) == len(df)
 
-    # solve issue of duplicate gauge symbols
-    df["symbol"] = df["symbol"] + "-" + df["address"].str[2:6]
+    # solve issue of duplicate pool symbols
+    df["symbol"] = df["symbol"] + "-" + df["address"].str[2:7]
 
     # confirm no duplicate symbols exist, raise if so
     if len(df["symbol"].unique()) != len(df):


### PR DESCRIPTION
Found issue where deployed gyro pools start with same set of symbols at index 2:6. Increasing appending of address substring by one index will solve the issue:

Found duplicate symbols!
                                        address           symbol
880  0xc97182ddb330a165eaf322651930dba0a8a40e48  WETH-EIGEN-c971
881  0xc971ecf12c7a201a26e3d46a612add9cb1d5b086  WETH-EIGEN-c971