### PR TITLE
chore: add emergency safe on Monad

### DIFF
--- a/extras/multisigs.json
+++ b/extras/multisigs.json
@@ -180,7 +180,8 @@
     "omni": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
     "balancer_onchain_ltd": "0x16b0056636Fcc85f92C49cD49a24bc519d4A1941",
     "balancer_bizdev": "0xF3B4829C8B9E2910C2396538F49a12b0c2475a7e",
-    "maxyz_operator": "0xBeF27037bC6311b96635E5e9Af3A73EBF6Ca8878"
+    "maxyz_operator": "0xBeF27037bC6311b96635E5e9Af3A73EBF6Ca8878",
+    "emergency": "0x3a921d6956C62012Dd88f95bD44224a7Ef5C9b5a"
   },
   "bnb": {
     "_deprecated": {


### PR DESCRIPTION
Safe: https://app.safe.global/home?safe=monad:0x3a921d6956C62012Dd88f95bD44224a7Ef5C9b5a

Can confirm signer set based on other safes, e.g. Plasma: https://app.safe.global/settings/setup?safe=plasma:0x0d3319A8057A0C8afd87dFEEA252541A76d56Ebf 