### PR TITLE
chore: add monad & xlayer as prod chains

### DIFF
--- a/extras/chains.json
+++ b/extras/chains.json
@@ -68,7 +68,9 @@
     "hyperevm",
     "fraxtal",
     "optimism",
-    "plasma"
+    "plasma",
+    "monad",
+    "xlayer"
   ],
   "BALANCER_PRODUCTION_CHAINS_V3": [
     "mainnet",
@@ -79,6 +81,7 @@
     "optimism",
     "avalanche",
     "plasma",
+    "monad",
     "xlayer"
   ]
 }


### PR DESCRIPTION
- add monad and xlayer to production chains entries so that permissions artifacts are upgraded accordingly now that https://github.com/BalancerMaxis/multisig-ops/pull/2657 and https://github.com/BalancerMaxis/multisig-ops/pull/2662 have been executed successfully