### PR TITLE
chore: add blabs team and fundraise safes to mainnet

### DIFF
--- a/extras/multisigs.json
+++ b/extras/multisigs.json
@@ -13,6 +13,8 @@
     "maxyz_operator": "0xBeF27037bC6311b96635E5e9Af3A73EBF6Ca8878",
     "aura_locker": "0x9a5BDF08a6969A4bDb7724beE3c6d8964BDc0B28",
     "blabs_ops": "0x02f35dA6A02017154367Bc4d47bb6c7D06C7533B",
+    "blabs_team": "0xCDcEBF1f28678eb4A1478403BA7f34C94F7dDBc5",
+    "blabs_fundraise": "0xB129F73f1AFd3A49C701241F374dB17AE63B20Eb",
     "linearPoolController": "0x75a52c0e32397A3FC0c052E2CeB3479802713Cf4",
     "foundation_opco": "0x3B8910F378034FD6E103Df958863e5c684072693",
     "beets_service_provider": "0x811912c19eEF91b9Dc3cA52fc426590cFB84FC86",


### PR DESCRIPTION
can be confirmed via etherscan labels or https://www.coingecko.com/en/coins/balancer (hover circ supply)